### PR TITLE
Přidána závislost na balíčku indentfirst

### DIFF
--- a/kibase.sty
+++ b/kibase.sty
@@ -81,6 +81,9 @@
 \RequirePackage{ifpdf}
 \RequirePackage{ifthen}
 
+%% Odsazení prvního odstavce v kapitole
+\RequirePackage{indentfirst}
+
 %% Seznam zkratek.
 \ifthenelse{\equal{\kib@glossaries}{true}}{
   %% glossaries definuje \printindex (definovany take makeidx) i kdyz


### PR DESCRIPTION
Balíček indentfirst způsobuje odsazení prvního odstavce každé kapitoly. To se aktuálně neděje kvůli tomu, že styl dědí z „article“ nikoliv „document“. Odsazené by ale dle mého názoru měly být.